### PR TITLE
refactor: Separate scraping logic into library and add unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scripts/bball_ref_scraper_lib.py
+++ b/scripts/bball_ref_scraper_lib.py
@@ -1,0 +1,163 @@
+import requests
+from bs4 import BeautifulSoup
+import logging
+
+# Configure logger for the library
+logger = logging.getLogger(__name__)
+
+def get_soup(url, timeout=10):
+    """Fetches URL and returns a BeautifulSoup object or None on error."""
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        return BeautifulSoup(response.content, 'html.parser')
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error fetching URL {url}: {e}")
+        return None
+
+def _get_cell_text(element, data_stat, player_name_for_log, game_url_for_log):
+    """Helper function to safely get cell text or None. Logs warning if not found."""
+    cell = element.find('td', attrs={"data-stat": data_stat})
+    text_val = cell.text.strip() if cell and cell.text.strip() else None
+    if text_val is None:
+        logger.warning(f"Stat [{data_stat}] not found for player [{player_name_for_log}] in game [{game_url_for_log}]")
+    return text_val
+
+def _to_int(value, stat_name, player_name_for_log, game_url_for_log):
+    """Helper function to convert to int or None. Logs warning on failure."""
+    if value is None or value == '':
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning(f"Could not convert stat [{stat_name}] value '{value}' to INTEGER for player [{player_name_for_log}] in game [{game_url_for_log}]")
+        return None
+
+def _to_real(value, stat_name, player_name_for_log, game_url_for_log):
+    """Helper function to convert to real or None. Logs warning on failure."""
+    if value is None or value == '':
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        logger.warning(f"Could not convert stat [{stat_name}] value '{value}' to REAL for player [{player_name_for_log}] in game [{game_url_for_log}]")
+        return None
+
+def parse_daily_games_page(soup, daily_url):
+    """
+    Parses the HTML content of a daily games page to find box score links.
+    Yields full box score URLs.
+    """
+    if not soup:
+        logger.warning(f"No soup object provided for parsing daily games page: {daily_url}")
+        return
+
+    game_links_found = 0
+    for game_link_p in soup.select('td.gamelink p.links a'):
+        href = game_link_p.get('href', '')
+        # Ensure it's a box score link and not a play-by-play or other sub-page link
+        if 'boxscores' in href and href.endswith('.html') and '/pbp/' not in href and '/shot-chart/' not in href and '/plus-minus/' not in href:
+            game_links_found +=1
+            yield f"https://www.basketball-reference.com{href}"
+
+    if game_links_found == 0:
+        logger.info(f"No box score links found on {daily_url}")
+
+
+def parse_box_score_page(soup, box_score_url):
+    """
+    Parses a single game's box score page.
+    Returns a dictionary with game details and a list of player stats.
+    """
+    if not soup:
+        logger.warning(f"No soup object provided for parsing box score page: {box_score_url}")
+        return None
+
+    game_data = {
+        "home_team": None, "away_team": None,
+        "home_score": None, "away_score": None,
+        "players": []
+    }
+
+    scorebox = soup.find('div', class_='scorebox')
+    if not scorebox:
+        logger.error(f"Could not find scorebox for {box_score_url}. Cannot parse game details.")
+        return None
+
+    teams = scorebox.find_all('strong')
+    team_names = [team.a.text if team.a else team.text for team in teams[:2]]
+    scores_elements = scorebox.find_all('div', class_='score')
+    final_scores_text = [score.text for score in scores_elements[:2]]
+
+    if len(team_names) == 2:
+        game_data["away_team"] = team_names[0] # Typically away team is listed first
+        game_data["home_team"] = team_names[1] # Home team second
+    else:
+        logger.error(f"Could not reliably extract team names for {box_score_url}. Found: {team_names}")
+        return None # Critical data missing
+
+    if len(final_scores_text) == 2:
+        try:
+            # Scores correspond to the team order: away_score is first, home_score is second
+            game_data["away_score"] = int(final_scores_text[0])
+            game_data["home_score"] = int(final_scores_text[1])
+        except ValueError:
+            logger.error(f"Could not parse scores as integers for {box_score_url} (Scores: {final_scores_text}).")
+            return None # Critical data missing
+    else:
+        logger.error(f"Could not reliably extract final scores for {box_score_url}. Found: {final_scores_text}")
+        return None # Critical data missing
+
+    player_stats_tables = soup.find_all('table', id=lambda x: x and x.startswith('box-') and x.endswith('-basic'))
+    if not player_stats_tables:
+        logger.warning(f"No basic player stats tables found for {box_score_url}.")
+
+    for table in player_stats_tables:
+        current_team_id_from_table = table.get('id').split('-')[1]
+        tbody = table.find('tbody')
+        if not tbody:
+            logger.warning(f"No tbody found in stats table for team {current_team_id_from_table} in game {box_score_url}")
+            continue
+
+        for row in tbody.find_all('tr'):
+            player_name_th = row.find('th', attrs={"data-stat": "player"})
+            if not player_name_th or not player_name_th.a:
+                if player_name_th and player_name_th.get_text(strip=True) not in ["Reserves", "Team Totals"]:
+                    logger.debug(f"Skipping row with th: {player_name_th.get_text(strip=True) if player_name_th else 'Unknown TH'} in game {box_score_url} as it's not a player link row.")
+                continue
+
+            player_name = player_name_th.a.text
+            mp_val = _get_cell_text(row, "mp", player_name, box_score_url)
+
+            non_playing_statuses = ["Did Not Play", "Not With Team", "Did Not Dress", "Inactive", "Player Suspended"]
+            if mp_val in non_playing_statuses or not mp_val:
+                logger.debug(f"Player [{player_name}] did not play or status is '{mp_val}'. Skipping stats for this player.")
+                continue
+
+            player_row_data = {
+                "player_name": player_name,
+                "team": current_team_id_from_table,
+                "mp": mp_val,
+                "fg": _to_int(_get_cell_text(row, "fg", player_name, box_score_url), "fg", player_name, box_score_url),
+                "fga": _to_int(_get_cell_text(row, "fga", player_name, box_score_url), "fga", player_name, box_score_url),
+                "fg_pct": _to_real(_get_cell_text(row, "fg_pct", player_name, box_score_url), "fg_pct", player_name, box_score_url),
+                "fg3": _to_int(_get_cell_text(row, "fg3", player_name, box_score_url), "fg3", player_name, box_score_url),
+                "fg3a": _to_int(_get_cell_text(row, "fg3a", player_name, box_score_url), "fg3a", player_name, box_score_url),
+                "fg3_pct": _to_real(_get_cell_text(row, "fg3_pct", player_name, box_score_url), "fg3_pct", player_name, box_score_url),
+                "ft": _to_int(_get_cell_text(row, "ft", player_name, box_score_url), "ft", player_name, box_score_url),
+                "fta": _to_int(_get_cell_text(row, "fta", player_name, box_score_url), "fta", player_name, box_score_url),
+                "ft_pct": _to_real(_get_cell_text(row, "ft_pct", player_name, box_score_url), "ft_pct", player_name, box_score_url),
+                "orb": _to_int(_get_cell_text(row, "orb", player_name, box_score_url), "orb", player_name, box_score_url),
+                "drb": _to_int(_get_cell_text(row, "drb", player_name, box_score_url), "drb", player_name, box_score_url),
+                "trb": _to_int(_get_cell_text(row, "trb", player_name, box_score_url), "trb", player_name, box_score_url),
+                "ast": _to_int(_get_cell_text(row, "ast", player_name, box_score_url), "ast", player_name, box_score_url),
+                "stl": _to_int(_get_cell_text(row, "stl", player_name, box_score_url), "stl", player_name, box_score_url),
+                "blk": _to_int(_get_cell_text(row, "blk", player_name, box_score_url), "blk", player_name, box_score_url),
+                "tov": _to_int(_get_cell_text(row, "tov", player_name, box_score_url), "tov", player_name, box_score_url),
+                "pf": _to_int(_get_cell_text(row, "pf", player_name, box_score_url), "pf", player_name, box_score_url),
+                "pts": _to_int(_get_cell_text(row, "pts", player_name, box_score_url), "pts", player_name, box_score_url),
+                "plus_minus": _get_cell_text(row, "plus_minus", player_name, box_score_url) # Will be None if not in basic table
+            }
+            game_data["players"].append(player_row_data)
+
+    return game_data

--- a/scripts/scrape_bball_reference.py
+++ b/scripts/scrape_bball_reference.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Overview:
+  This script scrapes game and player statistics from basketball-reference.com for a specified date range.
+  It fetches data from daily score pages and individual game box score pages, then stores the
+  extracted information into a SQLite database.
+
+Dependencies:
+  - requests: For making HTTP requests to fetch web page content.
+  - beautifulsoup4: For parsing HTML content.
+  - sqlite3: For database interaction (part of standard Python library).
+  - logging: For progress and error logging (part of standard Python library).
+  - os: For directory creation (part of standard Python library).
+  - sys: For exiting script on critical errors (part of standard Python library).
+  - datetime: For date manipulation (part of standard Python library).
+  - argparse: For command-line argument parsing (part of standard Python library).
+
+  Install external dependencies using:
+    pip install -r requirements.txt
+  (requirements.txt should contain 'requests' and 'beautifulsoup4')
+
+How to Run:
+  The script is executed from the command line, providing a start and end date.
+
+  Command-line usage:
+    python scripts/scrape_bball_reference.py --start_date YYYY-MM-DD --end_date YYYY-MM-DD
+
+  Example:
+    python scripts/scrape_bball_reference.py --start_date 2023-10-24 --end_date 2023-10-26
+
+  The start and end dates are inclusive. The script will process all days within this range.
+
+Database Schema:
+  The script creates a SQLite database file at `data/bball_data.db`.
+  The database contains two main tables: `games` and `player_stats`.
+  The `data/` directory is created automatically if it doesn't exist.
+
+  `games` table:
+    - id (INTEGER PRIMARY KEY AUTOINCREMENT): Unique identifier for each game.
+    - game_date (TEXT): Date of the game in YYYY-MM-DD format.
+    - home_team (TEXT): Name of the home team.
+    - away_team (TEXT): Name of the away team.
+    - home_score (INTEGER): Final score of the home team.
+    - away_score (INTEGER): Final score of the away team.
+    - box_score_url (TEXT UNIQUE): URL of the game's box score page. This is used to prevent
+                                   duplicate entries for the same game.
+
+  `player_stats` table:
+    - id (INTEGER PRIMARY KEY AUTOINCREMENT): Unique identifier for each player stat entry.
+    - game_id (INTEGER): Foreign key referencing the `id` in the `games` table, linking
+                         the player's stats to a specific game.
+    - player_name (TEXT): Name of the player.
+    - team (TEXT): Abbreviation of the team the player played for in this game (e.g., "LAL", "GSW").
+    - mp (TEXT): Minutes Played (e.g., "35:12"). Stored as text as it's not always a simple number.
+    - fg (INTEGER): Field Goals Made.
+    - fga (INTEGER): Field Goal Attempts.
+    - fg_pct (REAL): Field Goal Percentage (e.g., 0.450). Calculated as FG/FGA.
+    - fg3 (INTEGER): 3-Point Field Goals Made.
+    - fg3a (INTEGER): 3-Point Field Goal Attempts.
+    - fg3_pct (REAL): 3-Point Field Goal Percentage. Calculated as 3P/3PA.
+    - ft (INTEGER): Free Throws Made.
+    - fta (INTEGER): Free Throw Attempts.
+    - ft_pct (REAL): Free Throw Percentage. Calculated as FT/FTA.
+    - orb (INTEGER): Offensive Rebounds.
+    - drb (INTEGER): Defensive Rebounds.
+    - trb (INTEGER): Total Rebounds.
+    - ast (INTEGER): Assists.
+    - stl (INTEGER): Steals.
+    - blk (INTEGER): Blocks.
+    - tov (INTEGER): Turnovers.
+    - pf (INTEGER): Personal Fouls.
+    - pts (INTEGER): Points Scored.
+    - plus_minus (TEXT): Plus/Minus statistic (e.g., "+5", "-12"). Can be empty if not available
+                         or if the player did not play. Stored as text due to the '+' sign.
+
+Logging:
+  - The script logs its progress and any errors encountered.
+  - Logs are saved to a file at `logs/scraper.log`.
+  - Log messages are also printed to the console.
+  - The `data/` and `logs/` directories are created automatically by the script if they do not
+    already exist.
+"""
+
+import argparse
+import datetime
+# import requests # No longer directly used in main
+# from bs4 import BeautifulSoup # No longer directly used in main
+import sqlite3
+import os
+import bball_ref_scraper_lib # Import the new library
+import logging
+import sys
+
+# Configure logging
+def setup_logging():
+    """Sets up logging to file and console."""
+    log_dir = 'logs'
+    os.makedirs(log_dir, exist_ok=True)
+    log_file_path = os.path.join(log_dir, 'scraper.log')
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # File handler
+    file_handler = logging.FileHandler(log_file_path)
+    file_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    root_logger.addHandler(file_handler)
+
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    root_logger.addHandler(console_handler)
+
+def init_db(db_name='bball_data.db'):
+    """Initializes the database and creates tables if they don't exist."""
+    data_dir = 'data'
+    os.makedirs(data_dir, exist_ok=True)
+    db_path = os.path.join(data_dir, db_name)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Create games table
+    cursor.execute('''
+    CREATE TABLE IF NOT EXISTS games (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        game_date TEXT,
+        home_team TEXT,
+        away_team TEXT,
+        home_score INTEGER,
+        away_score INTEGER,
+        box_score_url TEXT UNIQUE
+    )
+    ''')
+
+    # Create player_stats table
+    cursor.execute('''
+    CREATE TABLE IF NOT EXISTS player_stats (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        game_id INTEGER,
+        player_name TEXT,
+        team TEXT,
+        mp TEXT,
+        fg INTEGER,
+        fga INTEGER,
+        fg_pct REAL,
+        fg3 INTEGER,
+        fg3a INTEGER,
+        fg3_pct REAL,
+        ft INTEGER,
+        fta INTEGER,
+        ft_pct REAL,
+        orb INTEGER,
+        drb INTEGER,
+        trb INTEGER,
+        ast INTEGER,
+        stl INTEGER,
+        blk INTEGER,
+        tov INTEGER,
+        pf INTEGER,
+        pts INTEGER,
+        plus_minus TEXT,
+        FOREIGN KEY (game_id) REFERENCES games (id)
+    )
+    ''')
+
+    conn.commit()
+    logging.info(f"Database initialized at {db_path}")
+    return conn
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Scrape basketball-reference.com for box score links within a date range.")
+    parser.add_argument("--start_date", required=True, help="Start date in YYYY-MM-DD format")
+    parser.add_argument("--end_date", required=True, help="End date in YYYY-MM-DD format")
+    return parser.parse_args()
+
+def daterange(start_date, end_date):
+    for n in range(int((end_date - start_date).days) + 1):
+        yield start_date + datetime.timedelta(n)
+
+def main():
+    setup_logging()
+    logging.info("Script started.")
+    args = parse_arguments()
+
+    games_processed_count = 0
+    players_inserted_count = 0
+
+    db_conn = init_db()
+    if not db_conn:
+        logging.error("Failed to initialize database. Exiting.")
+        sys.exit(1)
+    db_cursor = db_conn.cursor()
+
+    try:
+        start_date = datetime.datetime.strptime(args.start_date, "%Y-%m-%d").date()
+        end_date = datetime.datetime.strptime(args.end_date, "%Y-%m-%d").date()
+    except ValueError:
+        logging.error("Error: Dates must be in YYYY-MM-DD format. Please check input arguments.")
+        sys.exit(1)
+
+    if start_date > end_date:
+        logging.error("Error: Start date cannot be after end date.")
+        sys.exit(1)
+
+    for single_date in daterange(start_date, end_date):
+        single_date_str = single_date.strftime('%Y-%m-%d')
+        month = single_date.strftime("%m")
+        day = single_date.strftime("%d")
+        year = single_date.strftime("%Y")
+
+        daily_page_url = f"https://www.basketball-reference.com/boxscores/?month={month}&day={day}&year={year}"
+        logging.info(f"Processing date: {single_date_str}, URL: {daily_page_url}")
+
+        daily_soup = bball_ref_scraper_lib.get_soup(daily_page_url)
+
+        if not daily_soup:
+            # get_soup already logs the error, so just continue
+            continue
+
+        box_score_urls_found = list(bball_ref_scraper_lib.parse_daily_games_page(daily_soup, daily_page_url))
+
+        logging.info(f"Found {len(box_score_urls_found)} game(s) for date {single_date_str}.")
+        if not box_score_urls_found:
+            continue
+
+        for box_score_url in box_score_urls_found:
+            logging.info(f"  Fetching box score: {box_score_url}")
+
+            box_score_soup = bball_ref_scraper_lib.get_soup(box_score_url)
+            if not box_score_soup:
+                # get_soup already logs the error
+                continue
+
+            game_data = bball_ref_scraper_lib.parse_box_score_page(box_score_soup, box_score_url)
+
+            if not game_data or not game_data.get("home_team") or not game_data.get("away_team"): # Check critical fields
+                logging.error(f"    Could not parse critical game data (e.g. team names) from {box_score_url}. Skipping database insertion.")
+                continue
+
+            game_id_to_insert = None
+            try:
+                db_cursor.execute('''
+                    INSERT INTO games (game_date, home_team, away_team, home_score, away_score, box_score_url)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(box_score_url) DO NOTHING
+                ''', (single_date_str, game_data['home_team'], game_data['away_team'], game_data['home_score'], game_data['away_score'], box_score_url))
+
+                # Regardless of conflict, get the game_id
+                db_cursor.execute("SELECT id FROM games WHERE box_score_url = ?", (box_score_url,))
+                game_id_row = db_cursor.fetchone()
+                if game_id_row:
+                    game_id_to_insert = game_id_row[0]
+                else:
+                    # This case should ideally not happen if INSERT OR IGNORE worked or row existed.
+                    logging.error(f"    CRITICAL: Failed to retrieve game_id for {box_score_url} even after insert attempt. Skipping player stats.")
+                    continue
+
+            except sqlite3.Error as e:
+                logging.error(f"    Database error processing game {box_score_url}: {e}")
+                continue # Skip this game if DB error occurs during game insertion/query
+
+            if not game_id_to_insert: # Should be caught by the else above, but as a safeguard
+                logging.error(f"    No game_id obtained for {box_score_url}; cannot insert player stats. This indicates an issue.")
+                continue
+
+            current_game_players_inserted = 0
+            for player_stat_data in game_data.get("players", []):
+                # Add game_id to the player_stat_data
+                player_stat_data["game_id"] = game_id_to_insert
+
+                try:
+                    # Ensure all expected keys are present before forming SQL query
+                    # This list should match the player_stats table columns (excluding id)
+                    expected_keys = ["game_id", "player_name", "team", "mp", "fg", "fga", "fg_pct", "fg3", "fg3a",
+                                     "fg3_pct", "ft", "fta", "ft_pct", "orb", "drb", "trb", "ast", "stl",
+                                     "blk", "tov", "pf", "pts", "plus_minus"]
+
+                    # Create a list of values in the correct order
+                    values_to_insert = [player_stat_data.get(key) for key in expected_keys]
+
+                    columns = ', '.join(expected_keys)
+                    placeholders = ', '.join(['?'] * len(expected_keys))
+
+                    sql = f"INSERT INTO player_stats ({columns}) VALUES ({placeholders})"
+                    db_cursor.execute(sql, values_to_insert)
+                    current_game_players_inserted += 1
+                except sqlite3.Error as e:
+                    logging.error(f"    Database error inserting player stats for {player_stat_data.get('player_name', 'Unknown Player')} in game ID {game_id_to_insert} ({box_score_url}): {e}")
+                except KeyError as e:
+                    logging.error(f"    Missing expected key {e} in player data for {player_stat_data.get('player_name', 'Unknown Player')} in game {box_score_url}")
+
+            if current_game_players_inserted > 0:
+                db_conn.commit()
+                logging.info(f"    Successfully inserted/updated game (ID: {game_id_to_insert}) and inserted {current_game_players_inserted} player stat records for {box_score_url}.")
+                players_inserted_count += current_game_players_inserted
+                games_processed_count +=1 # Count game only if players were processed or game was newly added
+            elif game_id_to_insert: # Game existed or was inserted, but no new players were added
+                # Check if the game was newly inserted (lastrowid would be non-zero) or already existed
+                # This logic might be tricky if ON CONFLICT DO NOTHING doesn't update lastrowid consistently
+                # For simplicity, we'll assume if game_id_to_insert is valid, the game is "processed"
+                db_conn.commit() # Commit game insertion even if no players
+                logging.info(f"    Game (ID: {game_id_to_insert}) processed for {box_score_url}. No new player stats were added (either all skipped or already present).")
+                # To avoid double counting if game was already processed, we might need more sophisticated logic
+                # For now, let's increment if we attempted to insert game, implies it's a game we considered
+                if db_cursor.lastrowid: # A slightly more reliable check if game was newly inserted
+                    games_processed_count +=1
+
+
+    if db_conn:
+        db_conn.close()
+        logging.info("Database connection closed.")
+
+    logging.info(f"Script finished. Successfully processed and stored data for {games_processed_count} games and inserted {players_inserted_count} player stat records.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/sample_html/box_score_202310260MIL.html
+++ b/tests/sample_html/box_score_202310260MIL.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>76ers at Bucks Box Score, October 26, 2023</title>
+</head>
+<body>
+    <div class="scorebox">
+      <div class="teams">
+        <div class="team">
+          <a href="/teams/PHI/2024.html"><strong>Philadelphia 76ers</strong></a>
+          <div class="score">117</div>
+        </div>
+        <div class="team">
+          <a href="/teams/MIL/2024.html"><strong>Milwaukee Bucks</strong></a>
+          <div class="score">118</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="content_grid">
+        <!-- Philadelphia 76ers Basic Stats Table -->
+        <table id="box-PHI-game-basic">
+            <caption>Philadelphia 76ers Table</caption>
+            <thead>
+                <tr>
+                    <th data-stat="player" scope="col" class=" poptip sort_default_asc left">Player</th>
+                    <th data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played">MP</th>
+                    <th data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals">FG</th>
+                    <th data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts">FGA</th>
+                    <th data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage">FG%</th>
+                    <th data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals">3P</th>
+                    <th data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts">3PA</th>
+                    <th data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage">3P%</th>
+                    <th data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws">FT</th>
+                    <th data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts">FTA</th>
+                    <th data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage">FT%</th>
+                    <th data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds">ORB</th>
+                    <th data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds">DRB</th>
+                    <th data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds">TRB</th>
+                    <th data-stat="ast" scope="col" class=" poptip center" data-tip="Assists">AST</th>
+                    <th data-stat="stl" scope="col" class=" poptip center" data-tip="Steals">STL</th>
+                    <th data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks">BLK</th>
+                    <th data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers">TOV</th>
+                    <th data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls">PF</th>
+                    <th data-stat="pts" scope="col" class=" poptip center" data-tip="Points">PTS</th>
+                    <th data-stat="plus_minus" scope="col" class=" poptip center" data-tip="Plus/Minus">+/-</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/e/embiijo01.html">Joel Embiid</a></th>
+                    <td data-stat="mp">36:29</td><td data-stat="fg">9</td><td data-stat="fga">21</td>
+                    <td data-stat="fg_pct">.429</td><td data-stat="fg3">0</td><td data-stat="fg3a">3</td>
+                    <td data-stat="fg3_pct">.000</td><td data-stat="ft">6</td><td data-stat="fta">7</td>
+                    <td data-stat="ft_pct">.857</td><td data-stat="orb">1</td><td data-stat="drb">10</td>
+                    <td data-stat="trb">11</td><td data-stat="ast">5</td><td data-stat="stl">0</td>
+                    <td data-stat="blk">1</td><td data-stat="tov">7</td><td data-stat="pf">3</td>
+                    <td data-stat="pts">24</td><td data-stat="plus_minus">+2</td>
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/m/maxeyty01.html">Tyrese Maxey</a></th>
+                    <td data-stat="mp">39:51</td><td data-stat="fg">10</td><td data-stat="fga">22</td>
+                    <td data-stat="fg_pct">.455</td><td data-stat="fg3">3</td><td data-stat="fg3a">9</td>
+                    <td data-stat="fg3_pct">.333</td><td data-stat="ft">8</td><td data-stat="fta">8</td>
+                    <td data-stat="ft_pct">1.000</td><td data-stat="orb">1</td><td data-stat="drb">3</td>
+                    <td data-stat="trb">4</td><td data-stat="ast">8</td><td data-stat="stl">2</td>
+                    <td data-stat="blk">0</td><td data-stat="tov">1</td><td data-stat="pf">4</td>
+                    <td data-stat="pts">31</td><td data-stat="plus_minus">-5</td>
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/h/harrito02.html">Player EmptyStats</a></th>
+                    <td data-stat="mp">20:00</td><td data-stat="fg"></td><td data-stat="fga"></td>
+                    <td data-stat="fg_pct"></td><td data-stat="fg3"></td><td data-stat="fg3a"></td>
+                    <td data-stat="fg3_pct"></td><td data-stat="ft"></td><td data-stat="fta"></td>
+                    <td data-stat="ft_pct"></td><td data-stat="orb"></td><td data-stat="drb"></td>
+                    <td data-stat="trb"></td><td data-stat="ast"></td><td data-stat="stl"></td>
+                    <td data-stat="blk"></td><td data-stat="tov"></td><td data-stat="pf"></td>
+                    <td data-stat="pts"></td><td data-stat="plus_minus"></td>
+                </tr>
+                 <tr class="thead">
+                    <td colspan="20" class="center">Reserves</td>
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/o/oubreke01.html">Kelly Oubre Jr.</a></th>
+                     <td data-stat="mp">32:08</td><td data-stat="fg">9</td><td data-stat="fga">11</td>
+                     <td data-stat="fg_pct">.818</td><td data-stat="fg3">5</td><td data-stat="fg3a">6</td>
+                     <td data-stat="fg3_pct">.833</td><td data-stat="ft">4</td><td data-stat="fta">4</td>
+                     <td data-stat="ft_pct">1.000</td><td data-stat="orb">2</td><td data-stat="drb">2</td>
+                     <td data-stat="trb">4</td><td data-stat="ast">0</td><td data-stat="stl">1</td>
+                     <td data-stat="blk">0</td><td data-stat="tov">1</td><td data-stat="pf">5</td>
+                     <td data-stat="pts">27</td><td data-stat="plus_minus">+18</td>
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/s/smithja04.html">Player DNP</a></th>
+                    <td data-stat="mp" class="reason">Did Not Play</td><td data-stat="fg"></td><td data-stat="fga"></td>
+                    <td data-stat="fg_pct"></td><td data-stat="fg3"></td><td data-stat="fg3a"></td>
+                    <td data-stat="fg3_pct"></td><td data-stat="ft"></td><td data-stat="fta"></td>
+                    <td data-stat="ft_pct"></td><td data-stat="orb"></td><td data-stat="drb"></td>
+                    <td data-stat="trb"></td><td data-stat="ast"></td><td data-stat="stl"></td>
+                    <td data-stat="blk"></td><td data-stat="tov"></td><td data-stat="pf"></td>
+                    <td data-stat="pts"></td><td data-stat="plus_minus"></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <!-- Milwaukee Bucks Basic Stats Table -->
+        <table id="box-MIL-game-basic">
+            <caption>Milwaukee Bucks Table</caption>
+            <thead>
+                <tr>
+                    <th data-stat="player" scope="col" class=" poptip sort_default_asc left">Player</th>
+                    <th data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played">MP</th>
+                    <th data-stat="pts" scope="col" class=" poptip center" data-tip="Points">PTS</th>
+                    <!-- other headers -->
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/a/antetgi01.html">Giannis Antetokounmpo</a></th>
+                    <td data-stat="mp">35:17</td><td data-stat="pts">23</td>
+                    <!-- other stats -->
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/l/lillada01.html">Damian Lillard</a></th>
+                    <td data-stat="mp">36:50</td><td data-stat="pts">39</td>
+                     <!-- other stats -->
+                </tr>
+            </tbody>
+        </table>
+
+        <!-- Milwaukee Bucks Advanced Stats Table (for plus_minus) -->
+        <table id="box-MIL-game-advanced">
+             <caption>Milwaukee Bucks Advanced Table</caption>
+            <thead>
+                <tr>
+                    <th data-stat="player" scope="col" class=" poptip sort_default_asc left">Player</th>
+                    <th data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played">MP</th>
+                    <th data-stat="plus_minus" scope="col" class=" poptip center" data-tip="Plus/Minus">+/-</th>
+                    <!-- other headers -->
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/a/antetgi01.html">Giannis Antetokounmpo</a></th>
+                    <td data-stat="mp">35:17</td><td data-stat="plus_minus">+7</td>
+                    <!-- other stats -->
+                </tr>
+                <tr>
+                    <th data-stat="player" scope="row" class="left "><a href="/players/l/lillada01.html">Damian Lillard</a></th>
+                    <td data-stat="mp">36:50</td><td data-stat="plus_minus">+1</td>
+                     <!-- other stats -->
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>

--- a/tests/sample_html/daily_games_oct26_2023.html
+++ b/tests/sample_html/daily_games_oct26_2023.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Daily Games Oct 26, 2023</title>
+</head>
+<body>
+    <table>
+        <tbody>
+            <tr> <!-- Game 1 -->
+                <td class="gamelink">
+                    <p class="links">
+                      <a href="/boxscores/202310260MIL.html">Box Score</a>
+                      <a href="/boxscores/pbp/202310260MIL.html">Play-by-Play</a>
+                    </p>
+                </td>
+                <td>Other data</td>
+            </tr>
+            <tr> <!-- Game 2 -->
+                <td class="gamelink">
+                    <p class="links">
+                      <a href="/boxscores/202310260LAL.html">Box Score</a>
+                      <a href="/boxscores/pbp/202310260LAL.html">Play-by-Play</a>
+                    </p>
+                </td>
+                <td>Other data</td>
+            </tr>
+            <tr> <!-- Game with no box score link in the right structure -->
+                <td>
+                    <p class="links">
+                      <a href="/some_other_page.html">Some Other Link</a>
+                    </p>
+                </td>
+                <td>Other data</td>
+            </tr>
+            <tr> <!-- Game where gamelink class is present, but no boxscore href -->
+                <td class="gamelink">
+                     <p class="links">
+                        <a href="/some_other_game_info.html">Game Info</a>
+                     </p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/tests/test_bball_ref_scraper_lib.py
+++ b/tests/test_bball_ref_scraper_lib.py
@@ -1,0 +1,192 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from bs4 import BeautifulSoup
+import requests # Import requests for its exceptions
+from pathlib import Path
+import logging
+
+# Attempt to import the library functions
+# This assumes the tests are run from the root of the repository,
+# or that the 'scripts' directory is in PYTHONPATH.
+try:
+    from scripts import bball_ref_scraper_lib
+except ImportError:
+    # Fallback for cases where scripts is not directly importable
+    # This might happen if tests are run from within the 'tests' directory itself
+    # without further sys.path manipulation. For robust testing,
+    # ensuring PYTHONPATH is set correctly or using a test runner that handles
+    # this (like pytest with project structure) is better.
+    import sys
+    sys.path.append(str(Path(__file__).parent.parent)) # Add repo root to path
+    from scripts import bball_ref_scraper_lib
+
+# Suppress logging during tests unless specifically testing logging
+logging.disable(logging.CRITICAL)
+
+
+class BaseScraperTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        base_path = Path(__file__).parent
+        cls.daily_html_content = (base_path / "sample_html/daily_games_oct26_2023.html").read_text()
+        cls.box_score_html_content = (base_path / "sample_html/box_score_202310260MIL.html").read_text()
+
+        cls.daily_soup = BeautifulSoup(cls.daily_html_content, 'html.parser')
+        cls.box_score_soup = BeautifulSoup(cls.box_score_html_content, 'html.parser')
+
+class TestHelperFunctions(unittest.TestCase):
+    def test_to_int(self):
+        self.assertEqual(bball_ref_scraper_lib._to_int("5", "stat", "player", "game_url"), 5)
+        self.assertIsNone(bball_ref_scraper_lib._to_int("", "stat", "player", "game_url"))
+        self.assertIsNone(bball_ref_scraper_lib._to_int(None, "stat", "player", "game_url"))
+        self.assertIsNone(bball_ref_scraper_lib._to_int("abc", "stat", "player", "game_url"))
+        self.assertEqual(bball_ref_scraper_lib._to_int(" -5 ", "stat", "player", "game_url"), -5) # Test with spaces
+
+    def test_to_real(self):
+        self.assertEqual(bball_ref_scraper_lib._to_real(".500", "stat", "player", "game_url"), 0.5)
+        self.assertIsNone(bball_ref_scraper_lib._to_real("", "stat", "player", "game_url"))
+        self.assertIsNone(bball_ref_scraper_lib._to_real(None, "stat", "player", "game_url"))
+        self.assertIsNone(bball_ref_scraper_lib._to_real("abc", "stat", "player", "game_url"))
+        self.assertEqual(bball_ref_scraper_lib._to_real(" 0.75 ", "stat", "player", "game_url"), 0.75) # Test with spaces
+
+
+class TestGetSoup(unittest.TestCase):
+    @patch('scripts.bball_ref_scraper_lib.requests.get')
+    def test_get_soup_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = "<html><body><p>Test</p></body></html>"
+        mock_get.return_value = mock_response
+
+        soup = bball_ref_scraper_lib.get_soup("http://example.com")
+        self.assertIsNotNone(soup)
+        self.assertEqual(soup.find("p").text, "Test")
+        mock_get.assert_called_once_with("http://example.com", timeout=10)
+
+    @patch('scripts.bball_ref_scraper_lib.requests.get')
+    def test_get_soup_http_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Error")
+        mock_get.return_value = mock_response
+
+        # Enable logging temporarily for this test to check log output
+        logging.disable(logging.NOTSET)
+        with self.assertLogs(logger=bball_ref_scraper_lib.logger, level='ERROR') as cm:
+            soup = bball_ref_scraper_lib.get_soup("http://example.com/404")
+        self.assertIsNone(soup)
+        self.assertTrue(any("Error fetching URL http://example.com/404" in message for message in cm.output))
+        logging.disable(logging.CRITICAL) # Disable again
+
+    @patch('scripts.bball_ref_scraper_lib.requests.get')
+    def test_get_soup_request_exception(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection failed")
+
+        logging.disable(logging.NOTSET)
+        with self.assertLogs(logger=bball_ref_scraper_lib.logger, level='ERROR') as cm:
+            soup = bball_ref_scraper_lib.get_soup("http://example.com/connection_error")
+        self.assertIsNone(soup)
+        self.assertTrue(any("Error fetching URL http://example.com/connection_error" in message for message in cm.output))
+        logging.disable(logging.CRITICAL)
+
+
+class TestParseDailyGamesPage(BaseScraperTest):
+    def test_parse_daily_games_page_found(self):
+        urls = list(bball_ref_scraper_lib.parse_daily_games_page(self.daily_soup, "dummy_daily_url"))
+        self.assertEqual(len(urls), 2)
+        self.assertIn("https://www.basketball-reference.com/boxscores/202310260MIL.html", urls)
+        self.assertIn("https://www.basketball-reference.com/boxscores/202310260LAL.html", urls)
+
+    def test_parse_daily_games_page_no_games(self):
+        empty_soup = BeautifulSoup("<html><body></body></html>", 'html.parser')
+        urls = list(bball_ref_scraper_lib.parse_daily_games_page(empty_soup, "dummy_empty_url"))
+        self.assertEqual(len(urls), 0)
+
+    def test_parse_daily_games_page_no_soup(self):
+        urls = list(bball_ref_scraper_lib.parse_daily_games_page(None, "dummy_none_soup_url"))
+        self.assertEqual(len(urls), 0)
+
+
+class TestParseBoxScorePage(BaseScraperTest):
+    def test_parse_box_score_page_valid(self):
+        game_data = bball_ref_scraper_lib.parse_box_score_page(self.box_score_soup, "dummy_box_score_url")
+        self.assertIsNotNone(game_data)
+
+        # Test team names and scores
+        self.assertEqual(game_data["home_team"], "Milwaukee Bucks")
+        self.assertEqual(game_data["away_team"], "Philadelphia 76ers")
+        self.assertEqual(game_data["home_score"], 118)
+        self.assertEqual(game_data["away_score"], 117)
+
+        # Test player data
+        # PHI: Embiid, Maxey, EmptyStats, Oubre Jr. (4)
+        # MIL: Giannis, Lillard (2)
+        # Total = 6 (Player DNP is skipped)
+        self.assertEqual(len(game_data["players"]), 6)
+
+        # Joel Embiid (PHI)
+        embiid = next(p for p in game_data["players"] if p["player_name"] == "Joel Embiid")
+        self.assertEqual(embiid["team"], "PHI")
+        self.assertEqual(embiid["mp"], "36:29")
+        self.assertEqual(embiid["fg"], 9)
+        self.assertEqual(embiid["fga"], 21)
+        self.assertEqual(embiid["fg_pct"], 0.429)
+        self.assertEqual(embiid["pts"], 24)
+        self.assertEqual(embiid["plus_minus"], "+2") # From basic table in this sample
+
+        # Player EmptyStats (PHI)
+        empty_stats_player = next(p for p in game_data["players"] if p["player_name"] == "Player EmptyStats")
+        self.assertEqual(empty_stats_player["team"], "PHI")
+        self.assertEqual(empty_stats_player["mp"], "20:00")
+        self.assertIsNone(empty_stats_player["fg"])
+        self.assertIsNone(empty_stats_player["fga"])
+        self.assertIsNone(empty_stats_player["fg_pct"])
+        self.assertIsNone(empty_stats_player["pts"])
+        self.assertIsNone(empty_stats_player["plus_minus"]) # Should be None as it's empty in basic
+
+        # Giannis Antetokounmpo (MIL) - check plus_minus from advanced if basic doesn't have it
+        # Note: The provided sample HTML for box_score has plus_minus in basic for Embiid.
+        # The library logic currently only checks basic tables.
+        # To test advanced table plus_minus, the sample HTML or library logic would need adjustment.
+        # For now, we'll test Giannis as found in MIL basic table.
+        giannis = next(p for p in game_data["players"] if p["player_name"] == "Giannis Antetokounmpo")
+        self.assertEqual(giannis["team"], "MIL")
+        self.assertEqual(giannis["mp"], "35:17")
+        self.assertEqual(giannis["pts"], 23)
+        # The sample HTML for MIL basic table doesn't have plus_minus, so it should be None
+        # The advanced table data for Giannis is +7. The current lib `parse_box_score_page`
+        # only parses basic tables. If we want to test merging, the lib needs to be updated.
+        # For this test, we expect None because only basic is parsed for all fields other than player name/mp
+        # The library was updated to take plus_minus from basic if available.
+        # The sample HTML for Giannis does not have plus_minus in basic table.
+        # The library's _get_cell_text will log a warning and return None.
+        self.assertIsNone(giannis["plus_minus"])
+
+
+    def test_parse_box_score_page_missing_scorebox(self):
+        malformed_soup = BeautifulSoup("<html><body><table id='box-MIL-game-basic'></table></body></html>", 'html.parser')
+        game_data = bball_ref_scraper_lib.parse_box_score_page(malformed_soup, "dummy_missing_scorebox_url")
+        self.assertIsNone(game_data)
+
+    def test_parse_box_score_page_no_player_tables(self):
+        # HTML with scorebox but no player stat tables
+        no_tables_html = """
+        <div class="scorebox">
+          <div><a href="#"><strong>Team A</strong></a><div class="score">100</div></div>
+          <div><a href="#"><strong>Team B</strong></a><div class="score">90</div></div>
+        </div>
+        """
+        no_tables_soup = BeautifulSoup(no_tables_html, 'html.parser')
+        game_data = bball_ref_scraper_lib.parse_box_score_page(no_tables_soup, "dummy_no_tables_url")
+        self.assertIsNotNone(game_data)
+        self.assertEqual(game_data["home_team"], "Team B") # Home team is the second one listed
+        self.assertEqual(game_data["away_team"], "Team A")
+        self.assertEqual(game_data["home_score"], 90) # Score of Team B
+        self.assertEqual(game_data["away_score"], 100) # Score of Team A
+        self.assertEqual(len(game_data["players"]), 0)
+
+    def test_parse_box_score_page_no_soup(self):
+        game_data = bball_ref_scraper_lib.parse_box_score_page(None, "dummy_none_soup_url")
+        self.assertIsNone(game_data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit refactors the basketball-reference.com scraper. The core scraping functionalities have been moved from the main script (`scripts/scrape_bball_reference.py`) into a new library file (`scripts/bball_ref_scraper_lib.py`).

Key changes:
-   **`scripts/bball_ref_scraper_lib.py`**: Contains functions for
    fetching HTML, parsing daily game pages to find box score
    URLs, parsing individual box score pages (extracting team info,
    scores, and detailed player stats), and helper functions for robust
    data type conversion. Uses its own logger.
-   **`scripts/scrape_bball_reference.py`**: Updated to import and use
    the new library. It continues to handle command-line argument
    parsing, date iteration, database initialization/interaction,
    logging setup, and overall orchestration.
-   **`tests/test_bball_ref_scraper_lib.py`**: A new test suite has been
    added with comprehensive unit tests for the scraping library.
    -   Uses `unittest` and `unittest.mock`.
    -   Includes tests for parsing daily game pages, individual box scores
        (team info, player stats, handling of 'Did Not Play' and empty stats),
        and data conversion helper functions.
    -   HTTP requests are mocked using `unittest.mock.patch`.
    -   Sample HTML files (`tests/sample_html/`) are used to provide
        consistent input for parsing tests.
    -   All 12 tests pass successfully.

This refactoring improves code organization, modularity, and maintainability. The addition of unit tests significantly increases the reliability of the scraping logic.